### PR TITLE
Rebased with latest API

### DIFF
--- a/nisyscfg/addons.py
+++ b/nisyscfg/addons.py
@@ -1,4 +1,3 @@
-import pkg_resources
 import sys
 import threading
 
@@ -11,10 +10,14 @@ class Addons(object):
     def __getattr__(self, name):
         with self._func_lock:
             if self._addons is None:
+                import pkg_resources
+
                 self._addons = {}
                 for entry_point in pkg_resources.iter_entry_points('nisyscfg_addons'):
                     self._addons[entry_point.name] = entry_point.load()
-        return self._addons[name]
+        if name in self._addons:
+            return self._addons[name]
+        raise AttributeError(name)
 
 
 sys.modules[__name__] = Addons()


### PR DESCRIPTION
Moved "import pkg_resources" to Addons.__getattr__ to fixed Python 2.7 addons tests
Expanding unit test coverage
Added class AddonMock, def entry_points_mock, and def test_create_filter_and_get_valid_properties
Added test_create_hardware_resource_and_get_valid_properties
Added test_expert_info_iterator_raises_error_after_close and test_hardware_resource_raises_error_after_close
Expanded test coverage. Added two tests: test_find_hardware_with_passed_filter_properties_specified, and test_filter_getattr_raises_error_when_invalid_addon_specified.
Updated addons.py to correctly return an attribute error.
Fixed _get_property() in HardwareResource to raise AttributeError when the PropDoesNotExist status code is returned