### PR TITLE
Added examples for NI-XNET hardware

### DIFF
--- a/examples/nixnet_assign_port_name.py
+++ b/examples/nixnet_assign_port_name.py
@@ -1,0 +1,54 @@
+import nisyscfg
+import nisyscfg.xnet
+import sys
+
+
+class DeviceNotFoundError(Exception):
+    pass
+
+
+class PortNotFoundError(Exception):
+    pass
+
+
+def nixnet_assign_port_name(serial_number, port_number, port_name):
+    with nisyscfg.Session() as session:
+        # Search for the NI-XNET device with the specified serial number.
+        device_filter = session.create_filter()
+        device_filter[nisyscfg.FilterProperties.IS_DEVICE] = True
+        device_filter[nisyscfg.FilterProperties.SERIAL_NUMBER] = serial_number
+
+        try:
+            # Assume only one device will be found
+            device = next(session.find_hardware(filter=device_filter, expert_names='xnet'))
+        except StopIteration:
+            raise DeviceNotFoundError('Could not find a device with serial number "{}"'.format(serial_number))
+
+        # Search for the interface connected to the NI-XNET device with the
+        # specified port number.
+        interface_filter = session.create_filter()
+        interface_filter[nisyscfg.FilterProperties.IS_DEVICE] = False
+        interface_filter[nisyscfg.FilterProperties.CONNECTS_TO_LINK_NAME] = (
+            device[nisyscfg.ResourceProperties.PROVIDES_LINK_NAME]
+        )
+        interface_filter[nisyscfg.xnet.FilterProperties.PORT_NUMBER] = port_number
+
+        try:
+            # Assume only one interface will be found
+            interface = next(session.find_hardware(filter=interface_filter, expert_names='xnet'))
+        except StopIteration:
+            raise PortNotFoundError(
+                'Device with serial number "{}" does not have port number {}'.format(serial_number, port_number))
+
+        interface.rename(port_name)
+
+
+if '__main__' == __name__:
+    if len(sys.argv) != 4:
+        print("Usage: {} <serial_number> <port_number> <port_name>".format(sys.argv[0]))
+        sys.exit(1)
+
+    serial_number = sys.argv[1].upper()
+    port_number = int(sys.argv[2])
+    port_name = sys.argv[3]
+    nixnet_assign_port_name(serial_number, port_number, port_name)

--- a/examples/nixnet_blink_port_led.py
+++ b/examples/nixnet_blink_port_led.py
@@ -1,0 +1,38 @@
+import nisyscfg
+import nisyscfg.xnet
+import sys
+
+
+class PortNotFoundError(Exception):
+    pass
+
+
+def nixnet_blink_port_led(port_name, mode):
+    with nisyscfg.Session() as session:
+        # Search for the NI-XNET interface with port name.
+        interface_filter = session.create_filter()
+        interface_filter[nisyscfg.FilterProperties.IS_DEVICE] = False
+        interface_filter[nisyscfg.FilterProperties.USER_ALIAS] = port_name
+
+        try:
+            # Assume only one interface will be found
+            interface = next(session.find_hardware(filter=interface_filter, expert_names='xnet'))
+        except StopIteration:
+            raise PortNotFoundError('Could not find a port "{}"'.format(port_name))
+
+        # Set blink property and apply changes.
+        interface[nisyscfg.xnet.ResourceProperties.BLINK] = mode
+        interface.save_changes()
+
+
+if '__main__' == __name__:
+    if len(sys.argv) != 3:
+        print("Usage: {} <port_name> on|off".format(sys.argv[0]))
+        sys.exit(1)
+
+    port_name = sys.argv[1]
+    mode = {
+        'on': nisyscfg.xnet.enums.XnetIntfBlink.ENABLE,
+        'off': nisyscfg.xnet.enums.XnetIntfBlink.DISABLE,
+    }[sys.argv[2].lower()]
+    nixnet_blink_port_led(port_name, mode)

--- a/examples/nixnet_upgrade_firmware.py
+++ b/examples/nixnet_upgrade_firmware.py
@@ -1,0 +1,33 @@
+import nisyscfg
+import sys
+
+
+class DeviceNotFoundError(Exception):
+    pass
+
+
+def nixnet_upgrade_firmware(serial_number):
+    with nisyscfg.Session() as session:
+        # Search for the NI-XNET device with the specified serial number.
+        device_filter = session.create_filter()
+        device_filter[nisyscfg.FilterProperties.IS_DEVICE] = True
+        device_filter[nisyscfg.FilterProperties.SERIAL_NUMBER] = serial_number
+
+        try:
+            # Assume only one device will be found
+            device = next(session.find_hardware(filter=device_filter, expert_names='xnet'))
+        except StopIteration:
+            raise DeviceNotFoundError('Could not find a device with serial number "{}"'.format(serial_number))
+
+        print('Starting firmware upgrade')
+        device.upgrade_firmware(version='0')
+        print('Completed firmware upgrade')
+
+
+if '__main__' == __name__:
+    if len(sys.argv) != 2:
+        print("Usage: {} <serial_number>".format(sys.argv[0]))
+        sys.exit(1)
+
+    serial_number = sys.argv[1].upper()
+    nixnet_upgrade_firmware(serial_number)

--- a/nisyscfg/xnet/__init__.py
+++ b/nisyscfg/xnet/__init__.py
@@ -1,2 +1,4 @@
 from nisyscfg.xnet.properties import Filter as FilterProperties  # noqa: F401
 from nisyscfg.xnet.properties import Resource as ResourceProperties  # noqa: F401
+
+from nisyscfg.xnet.enums import enums  # noqa: F401


### PR DESCRIPTION
* Added an example to assign a port name to an interface on an NI-XNET device
* Added an example to blink the LEDs on an NI-XNET interface
* Added an example to upgrade the firmware of an NI-XNET device
* Imported enums in the nisyscfg/xnet/__init__.py