### PR TITLE
Set prop fixes

### DIFF
--- a/nisyscfg/errors.py
+++ b/nisyscfg/errors.py
@@ -38,6 +38,8 @@ class LibraryError(Error):
 class LibraryWarning(Warning):
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
+        self.code = code
+        self.description = description
         if self.description:
             message = "Warning {0} occurred.\n{1}".format(str(code), description)
         else:

--- a/nisyscfg/system.py
+++ b/nisyscfg/system.py
@@ -1018,6 +1018,9 @@ class Session(object):
         if issubclass(c_type, nisyscfg.enums.BaseEnum):
             return c_type(value.value)
 
+        if issubclass(c_type, ctypes.c_void_p):
+            return value
+
         return c_string_decode(value.value)
 
     def _set_property(self, id, value, c_type, nisyscfg_type):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/tkrebes/nisyscfg-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This fixes an issue with setting system resource properties and allows warnings to be handled correctly.

### Why should this Pull Request be merged?

The following exception occurred because resourceHandle is past as an int instead of a c_void_p.
```
    return self._SetResourceProperty_cfunc(resourceHandle, propertyID, args)
ctypes.ArgumentError: argument 1: <class 'OverflowError'>: int too long to convert
```
Also when a warning was encountered, the following exception occurred:
```
AttributeError: 'LibraryWarning' object has no attribute 'description'
```
### What testing has been done?
Ran the following code snippet successfully on a Windows machine.
```python
import nisyscfg
session = nisyscfg.Session()
session.resource.system_configuration_web_access
session.resource.system_configuration_web_access = 1
session.resource.system_configuration_web_access
```
