### PR TITLE
Fixed c_type for item_type in component_info.py

### DIFF
--- a/nisyscfg/component_info.py
+++ b/nisyscfg/component_info.py
@@ -36,7 +36,7 @@ class ComponentInfoIterator(object):
         id = nisyscfg.types.simple_string()
         version = nisyscfg.types.simple_string()
         title = nisyscfg.types.simple_string()
-        item_type = nisyscfg.types.ctypes.c_long()
+        item_type = nisyscfg.types.ctypes.c_int()
         c_details = ctypes.POINTER(ctypes.c_char)()
         error_code = self._library.NextComponentInfo(
             self._handle, id, version, title, ctypes.pointer(item_type), c_details


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/tkrebes/nisyscfg-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Uses correct c_type for item_type in component_info.py

### Why should this Pull Request be merged?

Addressed issue with get_installed_software_components crashing on Ubuntu #38

### What testing has been done?

Successfully ran sample code from #38 on
- Windows 10 with Python 3.7.9 64-bit
- Ubuntu 20.04 with Python 3.8.10
