### PR TITLE
Updated xnet properties and fixed handling of timestamp properties

### DIFF
--- a/nisyscfg/errors.py
+++ b/nisyscfg/errors.py
@@ -41,9 +41,9 @@ class LibraryWarning(Warning):
         self.code = code
         self.description = description
         if self.description:
-            message = "Warning {0} occurred.\n{1}".format(str(code), description)
+            message = "Warning {0}: {1}".format(str(self.code), self.description)
         else:
-            message = "Warning {0} occurred.".format(str(code))
+            message = "Warning {0}:".format(str(self.code))
         super(LibraryWarning, self).__init__(message)
 
 

--- a/nisyscfg/hardware_resource.py
+++ b/nisyscfg/hardware_resource.py
@@ -3,6 +3,8 @@ from functools import reduce
 import nisyscfg.errors
 import nisyscfg.properties
 import nisyscfg.pxi.properties
+import nisyscfg.timestamp
+import nisyscfg.types
 import nisyscfg.xnet.properties
 import typing
 
@@ -150,7 +152,7 @@ class HardwareResource(object):
             return c_type(value.value)
 
         if c_type == nisyscfg.types.TimestampUTC:
-            return value
+            return nisyscfg.timestamp._convert_ctype_to_datetime(value)
 
         return c_string_decode(value.value)
 
@@ -172,7 +174,7 @@ class HardwareResource(object):
             return c_type(value.value)
 
         if c_type == nisyscfg.types.TimestampUTC:
-            return value
+            return nisyscfg.timestamp._convert_ctype_to_datetime(value)
 
         return c_string_decode(value.value)
 
@@ -198,6 +200,8 @@ class HardwareResource(object):
             value = c_string_encode(value)
         elif issubclass(c_type, nisyscfg.enums.BaseEnum):
             value = ctypes.c_int(value)
+        elif c_type == nisyscfg.types.TimestampUTC:
+            value = nisyscfg.timestamp._convert_datetime_to_ctype(value)
         else:
             value = c_type(value)
 

--- a/nisyscfg/properties.py
+++ b/nisyscfg/properties.py
@@ -51,8 +51,7 @@ class PropertyAccessor(object):
         self._setter(id, value, ctypes.c_char_p, PropertyType.STRING)
 
     def set_timestamp_property(self, id, value):
-        timestamp = nisyscfg.timestamp._convert_datatime_to_ctype(value)
-        self._setter(id, timestamp, nisyscfg.types.TimestampUTC, PropertyType.TIMESTAMP)
+        self._setter(id, value, nisyscfg.types.TimestampUTC, PropertyType.TIMESTAMP)
 
     def get_bool_property(self, id):
         return self._getter(id, Bool)
@@ -70,8 +69,7 @@ class PropertyAccessor(object):
         return self._getter(id, ctypes.c_char_p)
 
     def get_timestamp_property(self, id):
-        timestamp = self._getter(id, nisyscfg.types.TimestampUTC)
-        return nisyscfg.timestamp._convert_ctype_to_datatime(timestamp)
+        return self._getter(id, nisyscfg.types.TimestampUTC)
 
     def get_indexed_bool_property(self, id, index):
         return self._indexed_getter(id, index, Bool)
@@ -89,8 +87,7 @@ class PropertyAccessor(object):
         return self._indexed_getter(id, index, ctypes.c_char_p)
 
     def get_indexed_timestamp_property(self, id, index):
-        timestamp = self._indexed_getter(id, index, nisyscfg.types.TimestampUTC)
-        return nisyscfg.timestamp._convert_ctype_to_datatime(timestamp)
+        return self._indexed_getter(id, index, nisyscfg.types.TimestampUTC)
 
 
 class TypeProperty(object):

--- a/nisyscfg/timestamp.py
+++ b/nisyscfg/timestamp.py
@@ -12,7 +12,7 @@ import ctypes
 tai_epoch = datetime(year=1970, month=1, day=1)
 
 
-def _convert_ctype_to_datatime(timestamp: nisyscfg.types.TimestampUTC) -> datetime:
+def _convert_ctype_to_datetime(timestamp: nisyscfg.types.TimestampUTC) -> datetime:
     library = nisyscfg._library_singleton.get()
     seconds_since_tai_epoch = ctypes.c_uint64()
     fractional_seconds = ctypes.c_double()
@@ -31,7 +31,7 @@ def _convert_ctype_to_datatime(timestamp: nisyscfg.types.TimestampUTC) -> dateti
     )
 
 
-def _convert_datatime_to_ctype(timestamp: datetime) -> nisyscfg.types.TimestampUTC:
+def _convert_datetime_to_ctype(timestamp: datetime) -> nisyscfg.types.TimestampUTC:
     library = nisyscfg._library_singleton.get()
 
     time_since_tai_epoch = timestamp - tai_epoch

--- a/nisyscfg/timestamp.py
+++ b/nisyscfg/timestamp.py
@@ -12,42 +12,54 @@ import ctypes
 tai_epoch = datetime(year=1970, month=1, day=1)
 
 
+def is_blank_timestamp(timestamp):
+    return all(num == 0 for num in timestamp)
+
+
 def _convert_ctype_to_datetime(timestamp: nisyscfg.types.TimestampUTC) -> datetime:
-    library = nisyscfg._library_singleton.get()
-    seconds_since_tai_epoch = ctypes.c_uint64()
-    fractional_seconds = ctypes.c_double()
+    # This method returns 1 Jan 1904 if blank datetime is found(zero timestamp value).
+    # Else it converts the timestamp to datetime and returns
+    if is_blank_timestamp(timestamp):
+        return datetime(year=1904, month=1, day=1)
+    else:
+        library = nisyscfg._library_singleton.get()
+        seconds_since_tai_epoch = ctypes.c_uint64()
+        fractional_seconds = ctypes.c_double()
 
-    error_code = library.ValuesFromTimestamp(
-        timestamp,
-        ctypes.pointer(seconds_since_tai_epoch),
-        ctypes.pointer(fractional_seconds),
-    )
-    nisyscfg.errors.handle_error(None, error_code, is_error_handling=True)
+        error_code = library.ValuesFromTimestamp(
+            timestamp,
+            ctypes.pointer(seconds_since_tai_epoch),
+            ctypes.pointer(fractional_seconds),
+        )
+        nisyscfg.errors.handle_error(None, error_code, is_error_handling=True)
 
-    return (
-        tai_epoch
-        + timedelta(seconds=seconds_since_tai_epoch.value)
-        + timedelta(seconds=fractional_seconds.value)
-    )
+        return (
+            tai_epoch
+            + timedelta(seconds=seconds_since_tai_epoch.value)
+            + timedelta(seconds=fractional_seconds.value)
+        )
 
 
 def _convert_datetime_to_ctype(timestamp: datetime) -> nisyscfg.types.TimestampUTC:
-    library = nisyscfg._library_singleton.get()
+    if timestamp == datetime(year=1904, month=1, day=1):
+        return nisyscfg.types.TimestampUTC(0, 0, 0, 0)
+    else:
+        library = nisyscfg._library_singleton.get()
 
-    time_since_tai_epoch = timestamp - tai_epoch
-    seconds_since_tai_epoch = time_since_tai_epoch.days * 86400 + time_since_tai_epoch.seconds
-    fractional_seconds = (
-        (time_since_tai_epoch.microseconds / 10 ** 6)
-        + (time_since_tai_epoch.femtoseconds / 10 ** 15)
-        + (time_since_tai_epoch.yoctoseconds / 10 ** 24)
-    )
-    timestamp = nisyscfg.types.TimestampUTC()
+        time_since_tai_epoch = timestamp - tai_epoch
+        seconds_since_tai_epoch = time_since_tai_epoch.days * 86400 + time_since_tai_epoch.seconds
+        fractional_seconds = (
+            (time_since_tai_epoch.microseconds / 10 ** 6)
+            + (time_since_tai_epoch.femtoseconds / 10 ** 15)
+            + (time_since_tai_epoch.yoctoseconds / 10 ** 24)
+        )
+        timestamp = nisyscfg.types.TimestampUTC()
 
-    error_code = library.TimestampFromValues(
-        seconds_since_tai_epoch,
-        fractional_seconds,
-        ctypes.pointer(timestamp),
-    )
-    nisyscfg.errors.handle_error(None, error_code, is_error_handling=True)
+        error_code = library.TimestampFromValues(
+            seconds_since_tai_epoch,
+            fractional_seconds,
+            ctypes.pointer(timestamp),
+        )
+        nisyscfg.errors.handle_error(None, error_code, is_error_handling=True)
 
-    return timestamp
+        return timestamp

--- a/nisyscfg/xnet/enums.py
+++ b/nisyscfg/xnet/enums.py
@@ -9,6 +9,7 @@ class EnetPortMode(BaseEnum):
 class EnetPhyState(BaseEnum):
     SLAVE = 0
     MASTER = 1
+    AUTO = 2
 
 
 class Blink(BaseEnum):
@@ -29,6 +30,7 @@ class CanTransceiverCapability(BaseEnum):
     LS = 1
     XS = 3
     XS_WITH_HS_OR_LS = 4
+    UNKNOWN = 0xFFFFFFFF
 
 
 class DongleId(BaseEnum):

--- a/nisyscfg/xnet/enums.py
+++ b/nisyscfg/xnet/enums.py
@@ -21,7 +21,7 @@ class Protocol(BaseEnum):
     FLEXRAY = 1
     LIN = 2
     ETHERNET = 3
-    UNKNOWN = -2
+    UNKNOWN = 0xFFFFFFFE
 
 
 class CanTransceiverCapability(BaseEnum):

--- a/nisyscfg/xnet/enums.py
+++ b/nisyscfg/xnet/enums.py
@@ -20,6 +20,7 @@ class Protocol(BaseEnum):
     CAN = 0
     FLEXRAY = 1
     LIN = 2
+    ETHERNET = 3
     UNKNOWN = -2
 
 

--- a/nisyscfg/xnet/enums.py
+++ b/nisyscfg/xnet/enums.py
@@ -66,3 +66,13 @@ class EnetInterruptModeration(BaseEnum):
     LOW = 1
     MEDIUM = 2
     HIGH = 3
+
+
+class EnetSleepCapability(BaseEnum):
+    DISABLED_OR_NOT_AVAILABLE = 0,
+    ENABLED = 1
+
+
+class EnetPhyPowerMode(BaseEnum):
+    NORMAL = 0,
+    SLEEP = 1

--- a/nisyscfg/xnet/properties.py
+++ b/nisyscfg/xnet/properties.py
@@ -16,12 +16,16 @@ from nisyscfg.xnet.enums import (
     EnetLinkSpeed,
     EnetJumboFrames,
     EnetInterruptModeration,
+    EnetSleepCapability,
+    EnetPhyPowerMode
 )
 
 
 class Resource(PropertyGroup):
     # Read-only device properties
     NUMBER_OF_PORTS = UnsignedIntProperty(167780352)
+    IP_STACK_INFO_JSON = StringProperty(167882752)
+    IP_STACK_INFO_TEXT = StringProperty(167886848)
 
     # Read-only port properties
     PORT_NUMBER = UnsignedIntProperty(167845888)
@@ -40,6 +44,8 @@ class Resource(PropertyGroup):
     ENET_OS_ADAPTER_NAME = StringProperty(167858176)
     ENET_OS_ADAPTER_DESC = StringProperty(167862272)
     ENET_LINK_SPEED = UnsignedIntProperty(167874560, EnetLinkSpeed)
+    ENET_SLEEP_CAPABILITY = UnsignedIntProperty(167911424, EnetSleepCapability)
+    ENET_PHY_POWER_MODE = UnsignedIntProperty(167915520, EnetPhyPowerMode)
 
     # Read/Write Automotive Ethernet port properties
     ENET_PHY_STATE = UnsignedIntProperty(167837696, EnetPhyState)
@@ -47,6 +53,7 @@ class Resource(PropertyGroup):
     ENET_LINK_SPEED_CONFIGURED = UnsignedIntProperty(167866368, EnetLinkSpeed)
     ENET_JUMBO_FRAMES = UnsignedIntProperty(167903232, EnetJumboFrames)
     ENET_INTERRUPT_MODERATION = IntProperty(167878656, EnetInterruptModeration)
+    ENET_SLEEP_CAPABILITY_CONFIGURED = UnsignedIntProperty(167907328, EnetSleepCapability)
 
 
 class Filter(PropertyGroup):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/tkrebes/nisyscfg-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Added properties for NI-XNET Ethernet devices
  - Added sleepCapability, phyPowerMode and IpStackInfo properties to Python nisyscfg
  - Added missing AE protocol to XNET
  - Updated Unknown Protocol enum value to match C API
  - Updated enums.py with missing values
- Fixed handling of timestamp properties
  - Fixed bug when setting time using nisyscfg
  - Fixed handling of empty timestamps
- Merged changes to errors.py

### Why should this Pull Request be merged?

These changes are patches created from the internal Python API that NI maintains. 

### What testing has been done?

Unit test passed.
