### PR TITLE
Changed pxi bitmask enum base type to enum.IntFlag

### DIFF
--- a/nisyscfg/enums.py
+++ b/nisyscfg/enums.py
@@ -1,9 +1,15 @@
 # This file is code generated
 
-from enum import IntEnum
+from enum import IntEnum, IntFlag
 
 
 class BaseEnum(IntEnum):
+    @classmethod
+    def from_param(cls, obj):
+        return int(obj)
+
+
+class BaseFlag(IntFlag):
     @classmethod
     def from_param(cls, obj):
         return int(obj)

--- a/nisyscfg/filter.py
+++ b/nisyscfg/filter.py
@@ -30,7 +30,9 @@ class Filter(object):
     def _set_property_with_type(self, id, value, c_type, nisyscfg_type):
         if c_type == ctypes.c_char_p:
             value = c_string_encode(value)
-        elif issubclass(c_type, nisyscfg.enums.BaseEnum):
+        elif issubclass(c_type, nisyscfg.enums.BaseEnum) or issubclass(
+            c_type, nisyscfg.enums.BaseFlag
+        ):
             value = ctypes.c_int(value)
         else:
             value = c_type(value)

--- a/nisyscfg/hardware_resource.py
+++ b/nisyscfg/hardware_resource.py
@@ -138,7 +138,9 @@ class HardwareResource(object):
         if c_type == ctypes.c_char_p:
             value = nisyscfg.types.simple_string()
             value_arg = value
-        elif issubclass(c_type, nisyscfg.enums.BaseEnum):
+        elif issubclass(c_type, nisyscfg.enums.BaseEnum) or issubclass(
+            c_type, nisyscfg.enums.BaseFlag
+        ):
             value = ctypes.c_int()
             value_arg = ctypes.pointer(value)
         else:
@@ -148,7 +150,9 @@ class HardwareResource(object):
         error_code = self._library.GetResourceProperty(self._handle, id, value_arg)
         nisyscfg.errors.handle_error(self, error_code)
 
-        if issubclass(c_type, nisyscfg.enums.BaseEnum):
+        if issubclass(c_type, nisyscfg.enums.BaseEnum) or issubclass(
+            c_type, nisyscfg.enums.BaseFlag
+        ):
             return c_type(value.value)
 
         if c_type == nisyscfg.types.TimestampUTC:
@@ -160,7 +164,9 @@ class HardwareResource(object):
         if c_type == ctypes.c_char_p:
             value = nisyscfg.types.simple_string()
             value_arg = value
-        elif issubclass(c_type, nisyscfg.enums.BaseEnum):
+        elif issubclass(c_type, nisyscfg.enums.BaseEnum) or issubclass(
+            c_type, nisyscfg.enums.BaseFlag
+        ):
             value = ctypes.c_int()
             value_arg = ctypes.pointer(value)
         else:
@@ -170,7 +176,9 @@ class HardwareResource(object):
         error_code = self._library.GetResourceIndexedProperty(self._handle, id, index, value_arg)
         nisyscfg.errors.handle_error(self, error_code)
 
-        if issubclass(c_type, nisyscfg.enums.BaseEnum):
+        if issubclass(c_type, nisyscfg.enums.BaseEnum) or issubclass(
+            c_type, nisyscfg.enums.BaseFlag
+        ):
             return c_type(value.value)
 
         if c_type == nisyscfg.types.TimestampUTC:
@@ -198,7 +206,9 @@ class HardwareResource(object):
     def _set_property(self, id, value, c_type, nisyscfg_type):
         if c_type == ctypes.c_char_p:
             value = c_string_encode(value)
-        elif issubclass(c_type, nisyscfg.enums.BaseEnum):
+        elif issubclass(c_type, nisyscfg.enums.BaseEnum) or issubclass(
+            c_type, nisyscfg.enums.BaseFlag
+        ):
             value = ctypes.c_int(value)
         elif c_type == nisyscfg.types.TimestampUTC:
             value = nisyscfg.timestamp._convert_datetime_to_ctype(value)

--- a/nisyscfg/pxi/enums.py
+++ b/nisyscfg/pxi/enums.py
@@ -1,4 +1,4 @@
-from nisyscfg.enums import BaseEnum
+from nisyscfg.enums import BaseEnum, BaseFlag
 
 
 class Clock10Sources(BaseEnum):
@@ -28,7 +28,7 @@ class PxiHighDensityTrigPortState(BaseEnum):
     LOOPBACK = 3  #: 2 High Density Trigger ports on the device are connected to each other
 
 
-class FanModes(BaseEnum):
+class FanModes(BaseFlag):
     AUTO = 1  #: Default operating mode
     SAFE_MANUAL = (
         2  #: Allows caller to manipulate the fan speed within safe boundaries by setting FanUserRpm
@@ -36,7 +36,7 @@ class FanModes(BaseEnum):
     HIGH = 4  #: Fans run at the maximum speed for the current cooling profile
 
 
-class CoolingProfiles(BaseEnum):
+class CoolingProfiles(BaseFlag):
     WATTS_38 = 1  #: Default operating mode
     WATTS_58 = (
         2  #: More aggressive cooling profile for cooling modules requiring 58W or less of cooling
@@ -88,7 +88,7 @@ class PowerSupplyStates(BaseEnum):
     ALERT_FAN = 61
 
 
-class InhibitModes(BaseEnum):
+class InhibitModes(BaseFlag):
     DEFAULT = 1  #: Chassis power controlled by the power button and OS
     MANUAL = 2  #: Chassis power controlled by the Remote Inhibit signal
 
@@ -99,7 +99,7 @@ class CalExtActions(BaseEnum):
     COMMIT = 2
 
 
-class ChassisLedBlinkPattern(BaseEnum):
+class ChassisLedBlinkPattern(BaseFlag):
     CHASSIS_CONTROLLED = 1
     ONE_BLINK = 2
     THREE_BLINK_BLINK_BLINK = 4

--- a/nisyscfg/pxi/properties.py
+++ b/nisyscfg/pxi/properties.py
@@ -1,5 +1,4 @@
 from nisyscfg.properties import (
-    BitmaskProperty,
     BoolProperty,
     IndexedDoubleProperty,
     IndexedStringProperty,
@@ -44,12 +43,12 @@ class Resource(PropertyGroup):
     # Fan control attributes
     FAN_MODE = UnsignedIntProperty(185597952, FanModes)
     FAN_USER_RPM = UnsignedIntProperty(185602048)
-    SUPPORTED_FAN_MODES = BitmaskProperty(185606144, FanModes)
+    SUPPORTED_FAN_MODES = UnsignedIntProperty(185606144, FanModes)
     FAN_MANUAL_RPM_LOWER_BOUND = UnsignedIntProperty(185634816)
     FAN_MANUAL_RPM_UPPER_BOUND = UnsignedIntProperty(185638912)
     COOLING_PROFILE = UnsignedIntProperty(185610240, CoolingProfiles)
     COOLING_PROFILE_SOURCE = IntProperty(185663488, CoolingProfileSource)
-    SUPPORTED_COOLING_PROFILES = BitmaskProperty(185614336, CoolingProfiles)
+    SUPPORTED_COOLING_PROFILES = UnsignedIntProperty(185614336, CoolingProfiles)
     # Honors a cooling profile user setting that is lower than a module
     # request when the module can accommodate the request by reducing
     # performance or functionality. A reboot may be required to take effect. */
@@ -59,7 +58,7 @@ class Resource(PropertyGroup):
     POWER_SUPPLY_BAY_COUNT = IntProperty(186777600)
     POWER_SUPPLIES_REDUNDANT = UnsignedIntProperty(186798080)
     INHIBIT_MODE = UnsignedIntProperty(186806272, InhibitModes)
-    SUPPORTED_INHIBIT_MODES = BitmaskProperty(186810368, InhibitModes)
+    SUPPORTED_INHIBIT_MODES = UnsignedIntProperty(186810368, InhibitModes)
 
     # Calibration attributes
     CAL_EXT_ACTION = UnsignedIntProperty(186908672, CalExtActions)

--- a/nisyscfg/system.py
+++ b/nisyscfg/system.py
@@ -1005,7 +1005,9 @@ class Session(object):
         if c_type == ctypes.c_char_p:
             value = nisyscfg.types.simple_string()
             value_arg = value
-        elif issubclass(c_type, nisyscfg.enums.BaseEnum):
+        elif issubclass(c_type, nisyscfg.enums.BaseEnum) or issubclass(
+            c_type, nisyscfg.enums.BaseFlag
+        ):
             value = ctypes.c_int()
             value_arg = ctypes.pointer(value)
         else:
@@ -1015,7 +1017,9 @@ class Session(object):
         error_code = self._library.GetSystemProperty(self._session, id, value_arg)
         nisyscfg.errors.handle_error(self, error_code)
 
-        if issubclass(c_type, nisyscfg.enums.BaseEnum):
+        if issubclass(c_type, nisyscfg.enums.BaseEnum) or issubclass(
+            c_type, nisyscfg.enums.BaseFlag
+        ):
             return c_type(value.value)
 
         if issubclass(c_type, ctypes.c_void_p):
@@ -1026,7 +1030,9 @@ class Session(object):
     def _set_property(self, id, value, c_type, nisyscfg_type):
         if c_type == ctypes.c_char_p:
             value = c_string_encode(value)
-        elif issubclass(c_type, nisyscfg.enums.BaseEnum):
+        elif issubclass(c_type, nisyscfg.enums.BaseEnum) or issubclass(
+            c_type, nisyscfg.enums.BaseFlag
+        ):
             value = ctypes.c_int(value)
         else:
             value = c_type(value)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/tkrebes/nisyscfg-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Removes BitmaskProperty as Python 3.6 and later have support for IntFlag
- Changes pxi bitmask enums base type to enum.IntFlag
- Updates nisyscfg API to treat BaseFlag just like BaseEnum

### Why should this Pull Request be merged?

Improves the usability of bitfield enum base type with IntFlag

### What testing has been done?

Checked that properties worked with a PXIe-1095 chassis
```
>>> import nisyscfg
>>> session = nisyscfg.Session()
>>> hw = list(session.find_hardware())
>>> hw[6]
HardwareResource(name=PXIChassis1)
>>> hw[6].pxi.fan_mode
<FanModes.AUTO: 1>
>>> hw[6].pxi.supported_fan_modes
<FanModes.HIGH|SAFE_MANUAL|AUTO: 7>
>>> hw[6].pxi.supported_cooling_profiles
<CoolingProfiles.WATTS_82|WATTS_58|WATTS_38: 7>
>>> hw[6].pxi.supported_inhibit_modes
<InhibitModes.MANUAL|DEFAULT: 3>
>>> hw[6].pxi.cooling_profile
<CoolingProfiles.WATTS_82: 4>
```
