### PR TITLE
Fixed library loading issue on Linux

### DIFF
--- a/nisyscfg/_library_singleton.py
+++ b/nisyscfg/_library_singleton.py
@@ -57,12 +57,14 @@ def get():
                 library_type = _get_library_type()
                 if library_type == "dual":
                     ctypes_library = CTypesLibrary(
-                        ctypes.CDLL(_get_library_name()),
+                        ctypes.CDLL(_get_library_name(), ctypes.RTLD_GLOBAL),
                         ctypes.WinDLL(_get_library_name()),
                     )
                 else:
                     assert library_type == "cdll"
-                    ctypes_library = CTypesLibrary(ctypes.CDLL(_get_library_name()))
+                    ctypes_library = CTypesLibrary(
+                        ctypes.CDLL(_get_library_name(), ctypes.RTLD_GLOBAL)
+                    )
             except OSError:
                 raise errors.LibraryNotInstalledError()
             _instance = _library.Library(ctypes_library)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -217,7 +217,7 @@ def test_open_close_session_invokes_nisyscfg_c_api(lib_mock):
     session = nisyscfg.Session()
     session.close()
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -237,7 +237,7 @@ def test_session_in_with_statement_invokes_nisyscfg_c_api(lib_mock):
     with nisyscfg.Session():
         pass
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -295,7 +295,7 @@ def test__get_status_description(lib_mock):
             nisyscfg.errors.Status.OUT_OF_MEMORY
         )
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -321,7 +321,7 @@ def test_get_system_experts_with_no_experts(lib_mock):
     with nisyscfg.Session() as session:
         session.get_system_experts()
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -365,7 +365,7 @@ def test_get_system_experts_with_two_experts(lib_mock):
     with nisyscfg.Session() as session:
         expert_info = list(session.get_system_experts())
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -421,7 +421,7 @@ def test_find_hardware_with_default_arguments(lib_mock):
     with nisyscfg.Session() as session:
         session.find_hardware()
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -451,7 +451,7 @@ def test_find_hardware_with_filter_properties_specified(lib_mock):
         filter.expert_name = "my_expert"
         session.find_hardware(filter)
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -525,7 +525,7 @@ def test_find_hardware_with_passed_filter_properties_specified(
         session.find_hardware(filter)
         property_id = getattr(nisyscfg.properties.Filter, property_name)._id
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -558,7 +558,7 @@ def test_create_filter(lib_mock):
     with nisyscfg.Session() as session:
         session.create_filter()
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -581,7 +581,7 @@ def test_create_filter_and_set_syscfg_filter_property(lib_mock):
         filter = session.create_filter()
         filter.expert_name = "my_expert"
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -609,7 +609,7 @@ def test_restart_with_default_arguments(lib_mock):
     with nisyscfg.Session() as session:
         session.restart()
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -632,7 +632,7 @@ def test_get_available_software_components_with_default_arguments(lib_mock):
     with nisyscfg.Session() as session:
         session.get_available_software_components()
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -656,7 +656,7 @@ def test_get_installed_software_components_with_default_arguments(lib_mock):
     with nisyscfg.Session() as session:
         session.get_installed_software_components()
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -697,7 +697,7 @@ def test_interating_over_hardware_resources(lib_mock):
         assert len(resources) == 3
 
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -762,7 +762,7 @@ def test_get_hardware_resource_property(
         property_id = getattr(nisyscfg.properties.Resource, property_name)._id
 
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -812,7 +812,7 @@ def test_get_hardware_resource_timestamp_property(
         property_id = nisyscfg.properties.Resource.CURRENT_TIME._id
 
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -973,7 +973,7 @@ def test_get_hardware_index_property(lib_mock, property_name, count_property, ex
         property_id = getattr(nisyscfg.properties.IndexedResource, property_name)._id
 
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,
@@ -1022,7 +1022,7 @@ def test_set_hardware_resource_timestamp_property(
         resource.current_time = nisyscfg.timestamp.tai_epoch + hightime.timedelta(seconds=100)
 
     expected_calls = [
-        mock.call(mock.ANY),
+        mock.call(mock.ANY, mock.ANY),
         mock.call().NISysCfgInitializeSession(
             mock.ANY,
             mock.ANY,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/tkrebes/nisyscfg-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Using ctypes.RTLB_GLOBAL flag allows necessary symbols to be loaded.

The [Python ctypes docs](https://docs.python.org/3/library/ctypes.html#ctypes.CDLL) state the default mode for the CDLL constructor is RTLD_LOCAL. [According to the Linux man pages](https://linux.die.net/man/3/dlopen), the dlopen syscall's RTLD_GLOBAL option causes the following loading behavior:

> The symbols defined by this library will be made available for symbol resolution of subsequently loaded libraries.
> [...]
> External references in the library are resolved using the libraries in that library's dependency list and any other libraries previously opened with the RTLD_GLOBAL flag

Contrast this with RTLD_LOCAL:

> This is the converse of RTLD_GLOBAL, and the default if neither flag is specified. Symbols defined in this library are not made available to resolve references in subsequently loaded libraries.

### Why should this Pull Request be merged?

On Linux targets, certain functions, namely NISysCfgRestart and and NISysCfgSetSystemImageFromFolder2, do not work when called from the wrapper, failing with the CMD_NOT_SUPPORTED error.

### What testing has been done?

Unit test passed