### PR TITLE
LedState: Add new enum possibilities that were added in 24.8

### DIFF
--- a/nisyscfg/enums.py
+++ b/nisyscfg/enums.py
@@ -251,8 +251,10 @@ class LedState(BaseEnum):
     OFF = 0
     SOLID_GREEN = 1
     SOLID_YELLOW = 2
+    SOLID_RED = 16
     BLINKING_GREEN = 4
     BLINKING_YELLOW = 8
+    BLINKING_RED = 32
 
 
 class SwitchState(BaseEnum):


### PR DESCRIPTION
Add Red LED states to the LedState enum. These states are available on the new mioDAQ devices.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/tkrebes/nisyscfg-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Defines new enum values that were added to sysapi

### Why should this Pull Request be merged?

API is now up to date

### What testing has been done?

Compared to source inside NI
