### PR TITLE
Updated build-and-publish job to use released gh-action-pypi-publish

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -30,16 +30,14 @@ jobs:
         run: python3 setup.py bdist_wheel
 
       - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.test_pypi_password }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
         continue-on-error: true
 
       - name: Publish distribution to PyPI
         if: github.event.action == 'published'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/tkrebes/nisyscfg-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Uses released version of pypa/gh-action-pypi-publish 

### Why should this Pull Request be merged?

This allows for the automated publishing of Python wheels to pypi.org

### What testing has been done?

none